### PR TITLE
fix: native backend warning and convert main functions to tests

### DIFF
--- a/src/funcref_map_inplace/funcref_map_inplace.mbti
+++ b/src/funcref_map_inplace/funcref_map_inplace.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "username/hello/funcref_map_inplace"
+
+import(
+  "moonbitlang/core/quickcheck/splitmix"
+)
+
+// Values
+
+// Errors
+
+// Types and methods
+type Point
+impl Compare for Point
+impl Eq for Point
+impl Show for Point
+impl @moonbitlang/core/quickcheck.Arbitrary for Point
+
+// Type aliases
+
+// Traits
+

--- a/src/funcref_map_inplace/moon.pkg.json
+++ b/src/funcref_map_inplace/moon.pkg.json
@@ -7,6 +7,5 @@
   },
   "native-stub": [
     "stub.c"
-  ],
-  "is-main": true
+  ]
 }

--- a/src/funcref_map_inplace/top.mbt
+++ b/src/funcref_map_inplace/top.mbt
@@ -18,7 +18,7 @@ fn map_inplace(xs : FixedArray[Point], closure : (Point) -> Point) -> Unit {
 }
 
 ///|
-fn main {
+test "map_inplace functionality" {
   let xs : FixedArray[Point] = @quickcheck.samples(4) |> FixedArray::from_array
   let mut i = 0
   fn f(x) {

--- a/src/funcref_map_inplace/top.mbt
+++ b/src/funcref_map_inplace/top.mbt
@@ -9,7 +9,7 @@ struct Point {
 extern "c" fn ffi_map_inplace(
   xs : FixedArray[Point],
   call : FuncRef[((Point) -> Point, Point) -> Point],
-  closure : (Point) -> Point
+  closure : (Point) -> Point,
 ) = "ffi_map_inplace"
 
 ///|

--- a/src/funcref_qsort/funcref_qsort.mbti
+++ b/src/funcref_qsort/funcref_qsort.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "username/hello/funcref_qsort"
+
+import(
+  "moonbitlang/core/quickcheck/splitmix"
+)
+
+// Values
+
+// Errors
+
+// Types and methods
+type Point
+impl Compare for Point
+impl Eq for Point
+impl Show for Point
+impl @moonbitlang/core/quickcheck.Arbitrary for Point
+
+// Type aliases
+
+// Traits
+

--- a/src/funcref_qsort/moon.pkg.json
+++ b/src/funcref_qsort/moon.pkg.json
@@ -1,5 +1,4 @@
 {
-  "is-main": true,
   "warn-list": "-1-2-3-4-5-6-9-28",
   "targets": {
     "top.mbt": [

--- a/src/funcref_qsort/top.mbt
+++ b/src/funcref_qsort/top.mbt
@@ -12,7 +12,7 @@ extern "c" fn qsort(
 ) = "ffi_qsort"
 
 ///|
-fn main {
+test "qsort functionality" {
   try {
     let xs : FixedArray[Point] = @quickcheck.samples(10)
       |> FixedArray::from_array

--- a/src/funcref_qsort/top.mbt
+++ b/src/funcref_qsort/top.mbt
@@ -8,7 +8,7 @@ struct Point {
 #borrow(xs, comp)
 extern "c" fn qsort(
   xs : FixedArray[Point],
-  comp : FuncRef[(Point, Point) -> Int]
+  comp : FuncRef[(Point, Point) -> Int],
 ) = "ffi_qsort"
 
 ///|
@@ -18,25 +18,25 @@ fn main {
       |> FixedArray::from_array
     let ys = xs.copy()
     let comp : FuncRef[(Point, Point) -> Int] = fn(x, y) { x.compare(y) }
-    inspect!(
+    inspect(
       xs,
       content="[{x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: -1}, {x: 2, y: 0}, {x: -2, y: 2}, {x: 0, y: 2}, {x: -5, y: -2}, {x: 2, y: 3}, {x: 3, y: 7}, {x: 1, y: 0}]",
     )
-    inspect!(
+    inspect(
       ys,
       content="[{x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: -1}, {x: 2, y: 0}, {x: -2, y: 2}, {x: 0, y: 2}, {x: -5, y: -2}, {x: 2, y: 3}, {x: 3, y: 7}, {x: 1, y: 0}]",
     )
     xs |> qsort(comp)
     ys.sort()
-    inspect!(
+    inspect(
       xs,
       content="[{x: -5, y: -2}, {x: -2, y: 2}, {x: 0, y: -1}, {x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: 2}, {x: 1, y: 0}, {x: 2, y: 0}, {x: 2, y: 3}, {x: 3, y: 7}]",
     )
-    inspect!(
+    inspect(
       ys,
       content="[{x: -5, y: -2}, {x: -2, y: 2}, {x: 0, y: -1}, {x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: 2}, {x: 1, y: 0}, {x: 2, y: 0}, {x: 2, y: 3}, {x: 3, y: 7}]",
     )
-    assert_eq!(xs, ys)
+    assert_eq(xs, ys)
     println("done")
   } catch {
     e => println(e)

--- a/src/funcref_qsort_closure/funcref_qsort_closure.mbti
+++ b/src/funcref_qsort_closure/funcref_qsort_closure.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "username/hello/funcref_qsort_closure"
+
+import(
+  "moonbitlang/core/quickcheck/splitmix"
+)
+
+// Values
+
+// Errors
+
+// Types and methods
+type Point
+impl Compare for Point
+impl Eq for Point
+impl Show for Point
+impl @moonbitlang/core/quickcheck.Arbitrary for Point
+
+// Type aliases
+
+// Traits
+

--- a/src/funcref_qsort_closure/moon.pkg.json
+++ b/src/funcref_qsort_closure/moon.pkg.json
@@ -1,5 +1,4 @@
 {
-  "is-main": true,
   "warn-list": "-1-2-3-4-5-6-9-28",
   "targets": {
     "top.mbt": [

--- a/src/funcref_qsort_closure/stub.c
+++ b/src/funcref_qsort_closure/stub.c
@@ -9,7 +9,7 @@ typedef moonbit_point_t *moonbit_fixedarray_point_t;
 typedef void* moonbit_closure_t;
 
 struct comp_context {
-  int (*call)(moonbit_closure_t colsure,moonbit_point_t lhs, moonbit_point_t rhs);
+  int (*call)(moonbit_closure_t closure,moonbit_point_t lhs, moonbit_point_t rhs);
   moonbit_closure_t closure;
 };
 

--- a/src/funcref_qsort_closure/top.mbt
+++ b/src/funcref_qsort_closure/top.mbt
@@ -18,7 +18,7 @@ fn qsort(xs : FixedArray[Point], comp : (Point, Point) -> Int) -> Unit {
 }
 
 ///|
-fn main {
+test "qsort_closure functionality" {
   try {
     let xs : FixedArray[Point] = @quickcheck.samples(10)
       |> FixedArray::from_array

--- a/src/funcref_qsort_closure/top.mbt
+++ b/src/funcref_qsort_closure/top.mbt
@@ -9,7 +9,7 @@ struct Point {
 extern "c" fn ffi_qsort(
   xs : FixedArray[Point],
   comp : FuncRef[((Point, Point) -> Int, Point, Point) -> Int],
-  closure : (Point, Point) -> Int
+  closure : (Point, Point) -> Int,
 ) = "ffi_qsort"
 
 ///|
@@ -29,25 +29,25 @@ fn main {
       println(i)
       x.compare(y)
     }
-    inspect!(
+    inspect(
       xs,
       content="[{x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: -1}, {x: 2, y: 0}, {x: -2, y: 2}, {x: 0, y: 2}, {x: -5, y: -2}, {x: 2, y: 3}, {x: 3, y: 7}, {x: 1, y: 0}]",
     )
-    inspect!(
+    inspect(
       ys,
       content="[{x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: -1}, {x: 2, y: 0}, {x: -2, y: 2}, {x: 0, y: 2}, {x: -5, y: -2}, {x: 2, y: 3}, {x: 3, y: 7}, {x: 1, y: 0}]",
     )
     xs |> qsort(comp)
     ys.sort()
-    inspect!(
+    inspect(
       xs,
       content="[{x: -5, y: -2}, {x: -2, y: 2}, {x: 0, y: -1}, {x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: 2}, {x: 1, y: 0}, {x: 2, y: 0}, {x: 2, y: 3}, {x: 3, y: 7}]",
     )
-    inspect!(
+    inspect(
       ys,
       content="[{x: -5, y: -2}, {x: -2, y: 2}, {x: 0, y: -1}, {x: 0, y: 0}, {x: 0, y: 0}, {x: 0, y: 2}, {x: 1, y: 0}, {x: 2, y: 0}, {x: 2, y: 3}, {x: 3, y: 7}]",
     )
-    assert_eq!(xs, ys)
+    assert_eq(xs, ys)
     println("done")
   } catch {
     e => println(e)

--- a/src/funcref_qsort_without_stub/funcref_qsort_without_stub.mbti
+++ b/src/funcref_qsort_without_stub/funcref_qsort_without_stub.mbti
@@ -1,0 +1,14 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "username/hello/funcref_qsort_without_stub"
+
+// Values
+
+// Errors
+
+// Types and methods
+type ConstPtr[T]
+
+// Type aliases
+
+// Traits
+

--- a/src/funcref_qsort_without_stub/moon.pkg.json
+++ b/src/funcref_qsort_without_stub/moon.pkg.json
@@ -1,5 +1,4 @@
 {
-  "is-main": true,
   "warn-list": "-1-2-3-4-5-6-9-28",
   "targets": {
     "top.mbt": [

--- a/src/funcref_qsort_without_stub/top.mbt
+++ b/src/funcref_qsort_without_stub/top.mbt
@@ -1,8 +1,10 @@
 ///|
-extern type ConstPtr[T]
+#external
+type ConstPtr[T]
 
 // TODO
 // pub fn ConstPtr::op_get[T](self : ConstPtr[T], index : Int) -> T = "%fixedarray.unsafe_get"
+
 ///|
 extern "c" fn ConstPtr::read_int(self : ConstPtr[Int], index : Int) -> Int = "ffi_read_int"
 
@@ -17,13 +19,13 @@ extern "c" fn qsort_ffi(
   xs : FixedArray[Int],
   count : UInt64,
   elem_size : UInt64,
-  comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int]
+  comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int],
 ) = "qsort"
 
 ///|
 fn qsort(
   xs : FixedArray[Int],
-  comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int]
+  comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int],
 ) -> Unit {
   qsort_ffi(xs, xs.length().to_uint64(), 4UL, comp)
 }
@@ -36,13 +38,13 @@ fn main {
     let comp : FuncRef[(ConstPtr[Int], ConstPtr[Int]) -> Int] = fn(x, y) {
       x.deref_int().compare(y.deref_int())
     }
-    inspect!(xs, content="[0, 0, 0, -1, -1, 0, 0, -1, 2, 5]")
-    inspect!(ys, content="[0, 0, 0, -1, -1, 0, 0, -1, 2, 5]")
+    inspect(xs, content="[0, 0, 0, -1, -1, 0, 0, -1, 2, 5]")
+    inspect(ys, content="[0, 0, 0, -1, -1, 0, 0, -1, 2, 5]")
     xs |> qsort(comp)
     ys.sort()
-    inspect!(xs, content="[-1, -1, -1, 0, 0, 0, 0, 0, 2, 5]")
-    inspect!(ys, content="[-1, -1, -1, 0, 0, 0, 0, 0, 2, 5]")
-    assert_eq!(xs, ys)
+    inspect(xs, content="[-1, -1, -1, 0, 0, 0, 0, 0, 2, 5]")
+    inspect(ys, content="[-1, -1, -1, 0, 0, 0, 0, 0, 2, 5]")
+    assert_eq(xs, ys)
     println("done")
   } catch {
     e => println(e)

--- a/src/funcref_qsort_without_stub/top.mbt
+++ b/src/funcref_qsort_without_stub/top.mbt
@@ -31,7 +31,7 @@ fn qsort(
 }
 
 ///|
-fn main {
+test "qsort_without_stub functionality" {
   try {
     let xs : FixedArray[Int] = @quickcheck.samples(10) |> FixedArray::from_array
     let ys = xs.copy()

--- a/src/funcref_register_callback/funcref_register_callback.mbti
+++ b/src/funcref_register_callback/funcref_register_callback.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "username/hello/funcref_register_callback"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/src/funcref_register_callback/moon.pkg.json
+++ b/src/funcref_register_callback/moon.pkg.json
@@ -1,5 +1,4 @@
 {
-  "is-main": true,
   "warn-list": "-1-2-3-4-5-6-9-28",
   "targets": {
     "top.mbt": [

--- a/src/funcref_register_callback/top.mbt
+++ b/src/funcref_register_callback/top.mbt
@@ -14,7 +14,7 @@ fn register_callback(closure : () -> Unit) -> Unit {
 }
 
 ///|
-fn main {
+test "register_callback functionality" {
   let s1 = "moonbit"
   register_callback(fn() {
     println(s1) // capture free variables

--- a/src/funcref_register_callback/top.mbt
+++ b/src/funcref_register_callback/top.mbt
@@ -2,7 +2,7 @@
 #borrow(call, closure)
 extern "c" fn ffi_register_callback(
   call : FuncRef[(() -> Unit) -> Unit],
-  closure : () -> Unit
+  closure : () -> Unit,
 ) = "register_callback"
 
 ///|


### PR DESCRIPTION
- Fixed typo in C code: 'colsure' -> 'closure' in funcref_qsort_closure/stub.c
- Converted all main functions to test functions across 5 packages:
  - funcref_register_callback
  - funcref_map_inplace  
  - funcref_qsort
  - funcref_qsort_closure
  - funcref_qsort_without_stub
- Removed "is-main": true from package configurations to enable proper testing
- Tests now run as MoonBit snapshot tests instead of main functions
- 4 out of 5 tests pass successfully (funcref_qsort_closure has runtime issue)

This improves the testing structure and makes the codebase more maintainable
by using proper test functions instead of main functions for testing.